### PR TITLE
Fixed compatibility issue with python 3.2

### DIFF
--- a/strudel/vobj.py
+++ b/strudel/vobj.py
@@ -1,6 +1,10 @@
 from .Parser import Parse
 from . import Fields
-from collections.abc import Sequence
+try:
+    from collections.abc import Sequence
+except ImportError:
+    # Backwards compatibility to python <= 3.2
+    from collections import Sequence
 from io import StringIO
 
 


### PR DESCRIPTION
collections.abc was introduced with python 3.3
